### PR TITLE
Adjust styling for Ada Lovelace's quote

### DIFF
--- a/web/generate_site/templates/index-base.html
+++ b/web/generate_site/templates/index-base.html
@@ -14,10 +14,14 @@
         <img style="width: 60%;" src="img/banner.png" />
       </div>
       <div class="col-md-5 p-lg-3 mx-auto my-5">
-        <p class="lead fw-normal">
-          "The more I study, the more insatiable do I feel my genius for it to be."
-        </p>
-        <h4>Ada Lovelace</h4>
+        <blockquote class="blockquote text-center">
+          <p>
+            <i class="fas fa-quote-left fa-xs pink"></i>
+            <span>The more I study, the more insatiable do I feel my genius for it to be.</span>
+            <i class="fas fa-quote-right fa-xs pink"></i>
+          </p>
+          <footer class="blockquote-footer">Ada Lovelace</footer>
+        </blockquote>
         <h1 class="pink display-4 fw-normal">PyLadiesCon</h1>
         <h4 class="gradient special-font">2023 Online</h4>
         <p class="lead fw-normal">

--- a/web/index.html
+++ b/web/index.html
@@ -64,10 +64,14 @@
         <img style="width: 60%;" src="img/banner.png" />
       </div>
       <div class="col-md-5 p-lg-3 mx-auto my-5">
-        <p class="lead fw-normal">
-          "The more I study, the more insatiable do I feel my genius for it to be."
-        </p>
-        <h4>Ada Lovelace</h4>
+        <blockquote class="blockquote text-center">
+          <p>
+            <i class="fas fa-quote-left fa-xs pink"></i>
+            <span>The more I study, the more insatiable do I feel my genius for it to be.</span>
+            <i class="fas fa-quote-right fa-xs pink"></i>
+          </p>
+          <footer class="blockquote-footer">Ada Lovelace</footer>
+        </blockquote>
         <h1 class="pink display-4 fw-normal">PyLadiesCon</h1>
         <h4 class="gradient special-font">2023 Online</h4>
         <p class="lead fw-normal">


### PR DESCRIPTION
I felt that it was not obvious that the quote is from Ada Lovelace. And the position of Ada Lovelace's name may look like she is part of PyLadies instead of the source of the quote.

I restyled it using the Bootstrap's [blockquote](https://getbootstrap.com/docs/4.0/content/typography/#blockquotes) element, and added pink quotations.

## Before:

The name appears very close to the PyLadiesCon, making it look like it's a conference by PyLadies and Ada Lovelace
![Screenshot 2023-09-07 at 7 06 25 PM](https://github.com/pyladies/global-conference/assets/5844587/4e2d4c1a-9df7-4a9f-ac44-84247bcea342)

## After:

The Ada Lovelace name is more subtle, and making it more obvious that the quote is from Ada Lovelace.

![Screenshot 2023-09-07 at 7 06 46 PM](https://github.com/pyladies/global-conference/assets/5844587/5d3479e8-e32d-4df8-bcb2-752840f6a1f0)




