### PR TITLE
For mobile, don't let Awesomic logo make screen too wide

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -19,6 +19,10 @@
   color: black;
 }
 
+.awesomic {
+  max-width: 100%;
+}
+
 .special-font {
   font-family: sans-serif;
   font-family: var(--special-font);

--- a/generate_site/templates/footer.html
+++ b/generate_site/templates/footer.html
@@ -21,8 +21,8 @@
     </div>
   </div>
   <div class="row justify-content-md-center">
-    <div class="col-3">
-      <a href="https://www.awesomic.com"><img src="img/awesomic-white.gif"/></a>
+    <div class="col-12">
+      <a href="https://www.awesomic.com"><img class="awesomic" src="img/awesomic-white.gif"/></a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
This should help with mobile layout.

# Mobile

## Before

<img width="404" alt="image" src="https://github.com/pyladies/global-conference/assets/1324225/21621173-c94e-4efd-a612-c88d531b80a2">

## After

<img width="398" alt="image" src="https://github.com/pyladies/global-conference/assets/1324225/7644ae70-e1b6-4b21-a991-7294c8a22f31">

# Desktop

## Before

<img width="1582" alt="image" src="https://github.com/pyladies/global-conference/assets/1324225/bdaf9d6a-2e32-4db8-bfb4-e81be156b57e">


## After

<img width="1582" alt="image" src="https://github.com/pyladies/global-conference/assets/1324225/33a36878-83bc-4751-ab5d-b64a58f54bfc">

Might need some adjustment to keep centred for desktop.