### PR TITLE
Simplify requirements

### DIFF
--- a/generate_site/generate.py
+++ b/generate_site/generate.py
@@ -1,26 +1,24 @@
+import csv
 import sys
-import requests
-import pandas as pd
 
 from pathlib import Path
 
-from jinja2 import Environment, FileSystemLoader, Template
+from jinja2 import Environment, FileSystemLoader
 
-
-# Files
-ORG = "organization.csv"
 
 # It is a dev run?
 dev = True if len(sys.argv) > 1 else False
 
-# Organization info
-df_org = pd.read_csv("organizers.csv")[["Name", "Role", "Biography"]]
-df_org.fillna("", inplace=True)
+# Organization info from the csv
+with open("organizers.csv") as f:
+    reader = csv.DictReader(f)
+    df_org = list(reader)
+
 # TODO: Download images? 'Headshot image' is the column name
 
 ##### Template configuration
 conf = {
-    "ORG": df_org.to_dict("records"),
+    "ORG": df_org,
 }
 
 templates = {

--- a/generate_site/requirements.txt
+++ b/generate_site/requirements.txt
@@ -1,3 +1,1 @@
-pandas
 jinja2
-requests


### PR DESCRIPTION
Pandas and requests are not needed. Removing them from the requirements reduces the risk of a broken build due to changes in dependencies and should also speed up local and CI installations