### PR TITLE
Set awesomic image to fit within its own container, in order to preve…

### DIFF
--- a/generate_site/templates/footer.html
+++ b/generate_site/templates/footer.html
@@ -21,8 +21,8 @@
     </div>
   </div>
   <div class="row justify-content-md-center">
-    <div class="col-3">
-      <a href="https://www.awesomic.com"><img src="img/awesomic-white.gif"/></a>
+    <div class="col-md-3">
+      <a href="https://www.awesomic.com"><img class="img-fluid" src="img/awesomic-white.gif"/></a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
…nt overflow left/right scroll on mobile.

Before:
![Screenshot from 2023-10-21 18-46-55](https://github.com/pyladies/global-conference/assets/14957396/a9398909-8bd5-482d-80a7-0edc17b6dfa9)

After: 
![Screenshot from 2023-10-21 18-47-21](https://github.com/pyladies/global-conference/assets/14957396/c42cda31-1636-4911-a4a9-d72364ffee33)

Desktop stays the same:
![Screenshot from 2023-10-21 19-09-22](https://github.com/pyladies/global-conference/assets/14957396/27f11892-a5df-4eba-bcf6-83796a9f94f0)
