### PR TITLE
Add explanation to schedule

### DIFF
--- a/generate_site/templates/schedule-base.html
+++ b/generate_site/templates/schedule-base.html
@@ -25,6 +25,12 @@
     </div>
   </div>
 
+  <div class="d-md-flex flex-md-equal w-100 my-md-3 ps-md-3">
+    <div class="bg-pink me-md-3 py-2 px-2 py-md-3 px-md-3 text-white overflow-hidden">
+       Use the Filter button to select the desired track. The dropdown next to the button will allow changing timezone from UTC to local timezone.
+    </div>
+  </div>
+
   <!-- begin pretalx -->
 <pretalx-schedule event-url="https://pretalx.com/pyladiescon-2023/" locale="en" format="grid" style="--pretalx-clr-primary: #ee264d"></pretalx-schedule>
 <noscript>


### PR DESCRIPTION
The embedded widget is confusing for people not used to the Pretalx schedule. Adding a text
as suggested on the report.

Closes #93 