### PR TITLE
Enable taxonomies and tagging

### DIFF
--- a/content/news/cfp_open.md
+++ b/content/news/cfp_open.md
@@ -34,7 +34,7 @@ Here are some ideas what you can talk about:
 
 Please remember, you **DO NOT** have to be an expert to share your experience or stories with us. You can share what you learn, what challenge you have overcome, or any good use-case of any Python libraries or open source technology that you know.
 
-For more details about how to write a CfP, you can see Cheuk’s blog post, in ([English](https://cheuk.dev/2023/06/06/how-to-be-speaker/)) and ([Spanish](https://cheuk.dev/2023/06/10/how-to-be-speaker-es/)).
+For more details about how to write a CfP, you can see Cheuk’s blog post, in [English](https://cheuk.dev/2023/06/06/how-to-be-speaker/) and [Spanish](https://cheuk.dev/2023/06/10/how-to-be-speaker-es/).
 
 This year we accept talks in multiple languages:
 

--- a/themes/pyladies/layouts/_default/taxonomy.html
+++ b/themes/pyladies/layouts/_default/taxonomy.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+ <section class="section">
+    <div class="container">
+      <div class="row gx-5">
+        <!-- blog posts -->
+        <div class="lg:col-8">
+          <div class="row">
+            {{ range .Data.Pages }}
+              <div class="md:col-6 mb-14">
+                {{ partial "components/blog-card" . }}
+              </div>
+            {{ end }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+{{ end }}

--- a/themes/pyladies/layouts/_default/terms.html
+++ b/themes/pyladies/layouts/_default/terms.html
@@ -1,0 +1,38 @@
+{{ define "main" }}
+  <section class="section">
+    <div class="container">
+      <ul>
+        {{/* categories */}}
+        {{ if eq .Permalink (`categories/` | absLangURL) }}
+          {{ range site.Taxonomies.categories.ByCount }}
+            <li>
+              <a
+                href="{{ .Page.Permalink }}"
+                class="bg-theme-light text-dark dark:bg-darkmode-theme-light dark:text-darkmode-dark block rounded px-4 py-2 text-xl">
+                {{ .Page.Title }}
+              </a>
+                <span class="bg-body dark:bg-darkmode-body ml-2 rounded px-2">
+                  {{ .Count }}
+                </span>
+            </li>
+          {{ end }}
+        {{ end }}
+        {{/* tags */}}
+        {{ if eq .Permalink (`tags/` | absLangURL) }}
+          {{ range site.Taxonomies.tags.ByCount }}
+            <li>
+              <a
+                href="{{ .Page.Permalink }}"
+                class="bg-theme-light text-dark dark:bg-darkmode-theme-light dark:text-darkmode-dark block rounded px-4 py-2 text-xl">
+                {{ .Page.Title }}
+              </a>
+                <span class="bg-body dark:bg-darkmode-body ml-2 rounded px-2">
+                  {{ .Count }}
+                </span>
+            </li>
+          {{ end }}
+        {{ end }}
+      </ul>
+    </div>
+  </section>
+{{ end }}

--- a/themes/pyladies/layouts/news/single.html
+++ b/themes/pyladies/layouts/news/single.html
@@ -1,15 +1,13 @@
 {{ define "main" }}
 
-  {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
-  {{ $dateHuman := .Date | time.Format ":date_long" }}
   <div class="d-md-flex flex-md-equal my-md-3 ps-md-3">
-    <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+
   </div>
   <h1 class="d-md-flex flex-md-equal my-md-3 ps-md-3 ">
       {{ .Title }}
   </h1>
   <p class="d-md-flex flex-md-equal my-md-3 ps-md-3 mb-3 desc">
-      written by {{ .Params.author }}
+      written by {{ .Params.author }} on {{ .Date | time.Format ":date_long" }}
   </p>
   <div class="my-md-3 ps-md-3">
       {{ .Content }}


### PR DESCRIPTION
Render the "tags" page.
Fix minor typo

# Tags are shown at the bottom of each blog post:
<img width="665" alt="Screenshot 2024-08-14 at 2 54 16 PM" src="https://github.com/user-attachments/assets/f6ecd0f3-d70a-4a50-a2b1-bcc12f4febba">


# Examples of all posts with "Python" tags: go to /tags/python
<img width="860" alt="Screenshot 2024-08-14 at 2 54 22 PM" src="https://github.com/user-attachments/assets/6c33e753-c543-40ee-b7fc-004c58932e30">

# Show all the tags: go to /tags

<img width="415" alt="Screenshot 2024-08-14 at 2 54 50 PM" src="https://github.com/user-attachments/assets/0e656f2b-fdbf-4a6b-87a1-f6026ec942ea">
