### PR TITLE
Remove CfP button

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -24,7 +24,7 @@ imagealt = "Website banner of PyLadiesCon 2024 Online. 6th-8th December | Multi-
           <a href="https://www.linkedin.com/company/pyladiescon"><i class="fab fa-linkedin fa-2x px-2" aria-hidden="true"></i></a>
         </div>
         <div class="w-50 mx-auto mt-2">
-          The Call for Proposal (CfP) is <span style="font-weight: 900; text-decoration-line: underline;">closed</span>.
+          The Call for Proposal (CfP) is <span style="font-weight: 900; text-decoration-line: underline;">closed</span> thank you for the submissions.
         </div>
       </div>
       <div class="col-md-5 p-lg-1 mx-auto my-5">

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,7 +24,7 @@ imagealt = "Website banner of PyLadiesCon 2024 Online. 6th-8th December | Multi-
           <a href="https://www.linkedin.com/company/pyladiescon"><i class="fab fa-linkedin fa-2x px-2" aria-hidden="true"></i></a>
         </div>
         <div class="w-50 mx-auto mt-2">
-          <a class="btn btn-outline-secondary btn-pink-gradient" href="https://pretalx.com/pyladiescon-2024/cfp" target="_blank">Call for proposal</a>
+          The Call for Proposal (CfP) is <span style="font-weight: 900; text-decoration-line: underline;">closed</span>.
         </div>
       </div>
       <div class="col-md-5 p-lg-1 mx-auto my-5">


### PR DESCRIPTION
The speaking page in the top menu is not removed
so speakers can find the URL to pretalx in order to modify proposals in the future.