### PR TITLE
fix: remove `pérez` accent

### DIFF
--- a/src/content/authors/denny-perez.md
+++ b/src/content/authors/denny-perez.md
@@ -1,5 +1,5 @@
 ---
-title: Denny Pérez
+title: Denny Perez
 meta_title: "About Denny"
 image: /images/authors/denny.jpg
 description: About Denny
@@ -9,7 +9,7 @@ social:
   linkedin: https://www.linkedin.com/in/dennyperez18/
 ---
 
-Denny Pérez, a Software Quality Analyst at Nventive; currently based in Canada. 
+Denny Perez, a Software Quality Analyst at Nventive; currently based in Canada.
 I graduated with a degree in Accounting from the Autonomous University of Santo Domingo and currently
 have over 10 years of professional experience in finance.
 

--- a/src/content/posts/2023-announcement-cfp-extended.mdx
+++ b/src/content/posts/2023-announcement-cfp-extended.mdx
@@ -5,7 +5,7 @@ description: "The first global PyLadies Conference CFP is extended"
 date: 2023-09-10T05:00:00Z
 image: "/images/posts/default2023.png"
 categories: ["Blog Post",]
-authors: ["Denny Pérez"]
+authors: ["Denny Perez"]
 tags: ["python", "community", "conference", "public speaking", "pyladies", "2023"]
 draft: false
 ---

--- a/src/content/posts/2023-announcement-cfp-launch.mdx
+++ b/src/content/posts/2023-announcement-cfp-launch.mdx
@@ -5,7 +5,7 @@ description: "The first global PyLadies Conference CFP is open"
 date: 2023-06-28T05:00:00Z
 image: "/images/posts/default2023.png"
 categories: ["Blog Post",]
-authors: ["Denny Pérez"]
+authors: ["Denny Perez"]
 tags: ["python", "community", "conference", "public speaking", "pyladies", "2023"]
 draft: false
 ---

--- a/src/content/posts/2023-announcement-pyladies-conference.mdx
+++ b/src/content/posts/2023-announcement-pyladies-conference.mdx
@@ -5,7 +5,7 @@ description: "The first global PyLadies Conference"
 date: 2023-06-22T05:00:00Z
 image: "/images/posts/default2023.png"
 categories: ["Blog Post",]
-authors: ["Denny Pérez"]
+authors: ["Denny Perez"]
 tags: ["python", "community", "conference", "public speaking", "pyladies", "2023"]
 draft: false
 ---

--- a/src/content/posts/2023-cfp-outreach-kit-spanish.mdx
+++ b/src/content/posts/2023-cfp-outreach-kit-spanish.mdx
@@ -3,7 +3,7 @@ title: "Cfp Outreach Kit - Spanish"
 meta_title: ""
 date: 2023-08-28T21:35:45-04:00
 draft: false
-authors: ['Denny Pérez']
+authors: ["Denny Perez"]
 description: "Queridas organizadoras, integrantes y seguidoras de PyLadies. Necesitamos su ayuda para difundir las novedades de PyLadiesCon 2023. Ustedes, como organizadoras y seguidoras de nuestra comunidad, pueden ayudarnos a llegar a personas que podrían ser excelentes ponentes para la conferencia y que quizás aún no hayan oído hablar de ella. Su conexión e introducción nos ayudarán a hacer que nuestra conferencia sea grandiosa."
 image: "/images/posts/default2023.png"
 imagealt: ""

--- a/src/content/posts/2023-cfp-outreach-kit-tchinese.mdx
+++ b/src/content/posts/2023-cfp-outreach-kit-tchinese.mdx
@@ -2,7 +2,7 @@
 title: 'Cfp Outreach Kit - Traditional Chinese'
 date: 2023-09-15T21:35:45-04:00
 draft: false
-authors: ['Denny Pérez']
+authors: ["Denny Perez"]
 description: '親愛的 PyLadies 組織者、成員及支持者。我們誠摯地邀請您幫助我們擴大 PyLadiesCon 2023 的影響力。作為我們的組織者、成員及支持者，您的支持對我們來說非常寶貴。我們希望您能協助尋找潛在的優秀講者，同時向尚未聽說過 PyLadiesCon 2023 的人介紹本活動。您的聯繫和推薦將使 PyLadiesCon 2023 更加出色。'
 image: "/images/posts/default2023.png"
 imagealt: ''

--- a/src/content/posts/2023-share-your-pyladies-chapter.mdx
+++ b/src/content/posts/2023-share-your-pyladies-chapter.mdx
@@ -5,7 +5,7 @@ description: ""
 date: 2023-11-03T05:00:00Z
 image: "/images/posts/default2023.png"
 categories: ["Blog Post",]
-authors: ["Denny Pérez"]
+authors: ["Denny Perez"]
 tags: ["python", "community", "conference", "public speaking", "pyladies", "2023"]
 draft: false
 ---

--- a/src/content/posts/2024-cfp-outreach-kit-french.mdx
+++ b/src/content/posts/2024-cfp-outreach-kit-french.mdx
@@ -2,7 +2,7 @@
 title: 'Cfp Outreach Kit - French'
 date: 2024-08-28T21:35:45-04:00
 draft: false
-authors: ['Denny Pérez']
+authors: ["Denny Perez"]
 description: "Chers organisateurs PyLadies, nous avons besoin de votre aide pour diffuser la nouvelle de PyLadiesCon. Vous, en tant qu'organisateurs, membres et partisans, pouvez contribuer à contacter des personnes qui pourraient être d'excellents intervenants pour la conférence, et qui pourraient ne pas avoir entendu parler de l'événement. Votre connexion et votre présentation contribueront à faire de notre conférence un événement exceptionnel."
 image: "/images/posts/default2024.png"
 imagealt: ''

--- a/src/content/posts/2024-cfp-outreach-kit-japanese.mdx
+++ b/src/content/posts/2024-cfp-outreach-kit-japanese.mdx
@@ -2,7 +2,7 @@
 title: 'Cfp Outreach Kit - Japanese'
 date: 2024-08-28T21:35:45-04:00
 draft: false
-authors: ['Denny Pérez']
+authors: ["Denny Perez"]
 description: 'PyLadies オーガナイザー, PyLadies メンバー, そしていつもPyLadiesをサポートしてくれてるみなさま。PyLadiesCon 2024 の情報を広めるために、ぜひ協力をおねがいします!'
 image: "/images/posts/default2024.png"
 imagealt: ''

--- a/src/content/posts/2024-cfp-outreach-kit-portuguese.mdx
+++ b/src/content/posts/2024-cfp-outreach-kit-portuguese.mdx
@@ -2,7 +2,7 @@
 title: 'Cfp Outreach Kit - Portuguese'
 date: 2024-08-28T21:35:45-04:00
 draft: false
-authors: ['Denny Pérez']
+authors: ["Denny Perez"]
 description: 'Prezadas organizadoras, membros e apoiantes da PyLadies. Precisamos da sua ajuda para espalhar a notícia da PyLadiesCon 2024. Você, como organizador ou organizadora, membro, apoiador ou apoiadora, pode ajudar-nos a alcançar pessoas que podem ser ótimas oradoras para a conferência e que talvez não saibam desta conferência. A sua rede de contactos pode tornar a nossa conferência excelente.'
 image: "/images/posts/default2024.png"
 imagealt: ''

--- a/src/content/posts/2024-cfp-outreach-kit-spanish.mdx
+++ b/src/content/posts/2024-cfp-outreach-kit-spanish.mdx
@@ -2,7 +2,7 @@
 title: 'Cfp Outreach Kit - Spanish'
 date: 2024-08-28T21:35:45-04:00
 draft: false
-authors: ['Denny Pérez']
+authors: ["Denny Perez"]
 description: 'Queridas organizadoras, integrantes y seguidoras de PyLadies. Necesitamos su ayuda para difundir las novedades de PyLadiesCon 2024. Ustedes, como organizadoras y seguidoras de nuestra comunidad, pueden ayudarnos a llegar a personas que podrían ser excelentes ponentes para la conferencia y que quizás aún no hayan oído hablar de ella. Su conexión e introducción nos ayudarán a hacer que nuestra conferencia sea grandiosa.'
 image: "/images/posts/default2024.png"
 imagealt: ''

--- a/src/content/posts/2024-cfp-outreach-kit-tchinese.mdx
+++ b/src/content/posts/2024-cfp-outreach-kit-tchinese.mdx
@@ -2,7 +2,7 @@
 title: 'Cfp Outreach Kit - Traditional Chinese'
 date: 2024-08-28T21:35:45-04:00
 draft: false
-authors: ['Denny Pérez']
+authors: ["Denny Perez"]
 description: '親愛的 PyLadies 組織者、成員及支持者。我們誠摯地邀請您幫助我們擴大 PyLadiesCon 2024 的影響力。作為我們的組織者、成員及支持者，您的支持對我們來說非常寶貴。我們希望您能協助尋找潛在的優秀講者，同時向尚未聽說過 PyLadiesCon 2024 的人介紹本活動。您的聯繫和推薦將使 PyLadiesCon 2024 更加出色。'
 image: "/images/posts/default2024.png"
 imagealt: ''

--- a/src/content/posts/2024-cfp-outreach-kit.mdx
+++ b/src/content/posts/2024-cfp-outreach-kit.mdx
@@ -2,7 +2,7 @@
 title: 'Cfp Outreach Kit'
 date: 2024-08-20T19:46:55-04:00
 draft: false
-authors: ['Denny Pérez']
+authors: ["Denny Perez"]
 description: 'Dear PyLadies organizers, members, and supporters. We need your help in spreading the news of PyLadiesCon 2024. You, as one of our organizers, members, and supporters, can help reach out to individuals who could be a great speaker for the conference and who might have yet to hear of the conference. Your connection and introduction will help make our conference great.'
 image: "/images/posts/default2024.png"
 imagealt: ''

--- a/src/content/posts/2024-registration-opens.mdx
+++ b/src/content/posts/2024-registration-opens.mdx
@@ -8,7 +8,7 @@ This year, we're bringing together Python enthusiasts worldwide to learn, share,
 date: 2024-11-15T05:00:00Z
 image: "/images/posts/default2024.png"
 categories: ["Blog Post",]
-authors: ["Denny Pérez"]
+authors: ["Denny Perez"]
 tags: ["python", "community", "conference", "public speaking", "pyladies"]
 draft: false
 ---

--- a/src/content/posts/2025-become-a-sponsor.mdx
+++ b/src/content/posts/2025-become-a-sponsor.mdx
@@ -5,7 +5,7 @@ description: "We’re excited to invite you to be part of the third edition of t
 date: 2025-07-25T12:00:00Z
 image: "/images/posts/call-for-sponsors.png"
 categories: ["Blog Post"]
-authors: ["Denny Pérez"]
+authors: ["Denny Perez"]
 tags: ["python", "community", "sponsors", "conference", "pyladies"]
 draft: false
 ---

--- a/src/content/posts/2025-video-chapter-request.mdx
+++ b/src/content/posts/2025-video-chapter-request.mdx
@@ -5,7 +5,7 @@ description: "We’re thrilled to invite all PyLadies chapters around the world 
 date: 2025-10-17T05:00:00Z
 image: "/images/posts/video-chapter-request.png"
 categories: ["Blog Post",]
-authors: ["Denny Pérez"]
+authors: ["Denny Perez"]
 tags: ["python", "community", "conference", "pyladies"]
 draft: false
 ---


### PR DESCRIPTION
Links from the `/blog` page were redirecting to `denny-pérez`.