### PR TITLE
fix: docs sidebar layout, container gap, and heading scale

### DIFF
--- a/src/layouts/DocSingle.astro
+++ b/src/layouts/DocSingle.astro
@@ -15,12 +15,8 @@ const { title, meta_title, description } = doc.data;
 const { Content } = await render(doc);
 ---
 
-<section class="section">
-  <div class="container">
-    <h1 set:html={markdownify(title)} class="page-heading-docs h2 mb-8" />
-    <TableOfContents headings={headings} />
-    <div class="content">
-      <Content />
-    </div>
-  </div>
-</section>
+<h1 set:html={markdownify(title)} class="page-heading-docs h2 mb-8" />
+<TableOfContents headings={headings} />
+<div class="content">
+  <Content />
+</div>

--- a/src/layouts/components/TableOfContents.astro
+++ b/src/layouts/components/TableOfContents.astro
@@ -10,7 +10,7 @@ const { headings } = Astro.props;
 const filteredHeadings = headings.filter((heading) => heading.depth <= 3);
 ---
 
-<nav class="bg-yellow-50 w-120 p-5">
+<nav class="bg-yellow-50 w-120 p-5 mb-5">
   <h3>Table of Contents</h3>
   <ul class="list-disc list-inside">
     {

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -44,9 +44,9 @@ const groupedDocs = groupDocsBySection(docs);
 >
   <section class="section">
     <div class="container-docs">
-      <div class="grid grid-cols-5">
-        <div class="hidden lg:flex">
-          <section class="section pt-2 bg-gray-100 rounded-lg text-sm">
+      <div class="grid grid-cols-1 gap-x-8 lg:grid-cols-[220px_1fr] xl:grid-cols-[260px_1fr] 2xl:grid-cols-[320px_1fr]">
+        <div class="hidden lg:flex w-full">
+          <section class="section pt-2 bg-gray-100 rounded-lg text-sm w-full">
             <div class="p-5">
               <p class="flex my-8 text-black font-bold">
                 <svg class="w-6 h-6 mr-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M6 2a2 2 0 0 0-2 2v15a3 3 0 0 0 3 3h12a1 1 0 1 0 0-2h-2v-2h2a1 1 0 0 0 1-1V4a2 2 0 0 0-2-2h-8v16h5v2H7a1 1 0 1 1 0-2h1V2H6Z" clip-rule="evenodd"/></svg>Documentation
@@ -87,7 +87,7 @@ const groupedDocs = groupDocsBySection(docs);
             </div>
           </section>
         </div>
-        <div class="col-span-4 mb-4 md:px-8">
+        <div class="mb-4">
           <DocSingle doc={doc} headings={headings} />
         </div>
       </div>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -9,7 +9,7 @@ const docs = await getSinglePage("docs");
 
 <Base title={"PyLadiesCon Documentation"}>
   <section class="section">
-    <div class="container">
+    <div class="container px-2">
       <div class="flex items-center">
         <svg class="w-10 h-10 mr-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M6 2a2 2 0 0 0-2 2v15a3 3 0 0 0 3 3h12a1 1 0 1 0 0-2h-2v-2h2a1 1 0 0 0 1-1V4a2 2 0 0 0-2-2h-8v16h5v2H7a1 1 0 1 1 0-2h1V2H6Z" clip-rule="evenodd"/></svg>
       <h1 set:text={markdownify("Documentation")} class="text-center h2" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,11 +4,11 @@ import Base from "@/layouts/Base.astro";
 
 const cards = [
   {
-    "title": "PyLadiesCon 2025",
+    "title": "PyLadiesCon 2026",
     "description": "Visit this year's website and learn more about the conference. More information soon!",
-    "button_url": "https://2025.conference.pyladies.com/en/",
+    "button_url": "https://2026.conference.pyladies.com/en/",
     "button_text": "Tell me more!",
-    "classes": "max-w-full p-6 border bg-red-100 border-gray-200 rounded-lg shadow-sm col-span-2 text-center",
+    "classes": "max-w-full p-6 border bg-blue-200 border-gray-200 rounded-lg shadow-sm col-span-2 text-center",
   },
   {
     "title": "Stay up to date",
@@ -27,6 +27,12 @@ const cards = [
 ]
 
 const previousEvents = [
+  {
+    "title": "2025 Conference Website",
+    "description": "Visit this year's website and learn more about the conference. More information soon!",
+    "button_url": "https://2025.conference.pyladies.com/en/",
+    "button_text": "Go to 2025 site",
+  },
   {
     "title": "2024 Conference Website",
     "description": "Visit 2024 website and learn more about the past conference.",

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -5,12 +5,12 @@
 
 /* container */
 .container {
-  @apply max-w-[1000px]! px-4! md:px-8! mx-auto;
+  @apply w-[80%]! max-w-[2000px]! px-4! md:px-8! mx-auto;
 }
 
 /* container-docs */
 .container-docs {
-  @apply max-w-[1280px]! px-4! md:px-8! mx-auto;
+  @apply w-[80%]! max-w-[2000px]! px-4! md:px-8! mx-auto;
 }
 
 /* page heading */
@@ -86,7 +86,7 @@
 
 /* content style */
 .content {
-  @apply prose max-w-none prose-headings:font-bold prose-h1:mb-4 prose-h1:text-h1-sm prose-h2:mb-4 prose-h2:mt-4 prose-h2:text-h2-sm prose-h3:mt-4 prose-h3:text-h3-sm prose-h4:mt-4 prose-h5:mb-4 prose-h6:mb-6 prose-blockquote:rounded-lg prose-blockquote:border-primary prose-blockquote:bg-light prose-blockquote:px-7 prose-blockquote:py-3 prose-blockquote:text-lg prose-blockquote:leading-8 prose-pre:px-6 prose-pre:py-5 md:prose-h1:text-h1 md:prose-h2:text-h2 md:prose-h3:text-h3;
+  @apply prose max-w-none prose-headings:font-bold prose-h1:mb-4 prose-h1:text-h3-sm prose-h2:mb-4 prose-h2:mt-4 prose-h2:text-h4-sm prose-h3:mt-4 prose-h3:text-h5-sm prose-h4:mt-4 prose-h5:mb-4 prose-h6:mb-6 prose-blockquote:rounded-lg prose-blockquote:border-primary prose-blockquote:bg-light prose-blockquote:px-7 prose-blockquote:py-3 prose-blockquote:text-lg prose-blockquote:leading-8 prose-pre:px-6 prose-pre:py-5 md:prose-h1:text-h3 md:prose-h2:text-h4 md:prose-h3:text-h5;
 }
 
 /* tab */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -7,6 +7,10 @@
 @import "./safe.css";
 @import "./utilities.css";
 
+@theme {
+    --color-pinkpyladies: #ee264d;
+}
+
 @layer base {
   @import "./base.css";
 }


### PR DESCRIPTION
Three related fixes to the /docs pages and shared content typography:

- src/pages/docs/[...slug].astro: the sidebar/content grid used a flat grid-cols-5 split (sidebar 1/5, content col-span-4), and the content column added its own md:px-8 on top of .container-docs's own px-8!, producing a lopsided gap between sidebar and content. Replaced with explicit per-breakpoint sidebar widths (220px/260px/320px at lg/xl/2xl) and gap-x-8 for spacing instead of one-sided padding, so the sidebar can grow independently and the gap is consistent.

- src/layouts/DocSingle.astro: dropped a redundant nested <section class="section"><div class="container"> wrapper. DocSingle only ever renders inside the grid's content column (already inside .container-docs), so the inner .container was re-narrowing itself to 80% *of that column* and re-centering, leaving the actual content indented on the left and stranded on the right instead of filling the available column width.

- src/styles/components.css (.content): prose h1/h2/h3 were sized at the full text-h1/h2/h3 scale (~48/40/33px against a 16px base), and docs/blog markdown bodies commonly repeat a top-level "# Title" heading in addition to the page's real `<h1>` (which is capped at .h2 size site-wide). That made in-body headings look bigger than the actual page title. Shifted prose heading sizes down two steps (h1->h3, h2->h4, h3->h5) so the hierarchy reads: page title > first content heading > sub-headings > body text.

Minor companion tweaks: src/pages/docs/index.astro (px-2 on the listing container) and src/layouts/components/TableOfContents.astro (mb-5 so the ToC box doesn't butt up against the next heading).